### PR TITLE
feat: added support for selecting fields in queries

### DIFF
--- a/admin/src/components/BuildingMaterialDialog.vue
+++ b/admin/src/components/BuildingMaterialDialog.vue
@@ -188,7 +188,7 @@ watch(
       nrService
         .find({
           $limit: 100,
-          $select: ['id', 'name'],
+          $select: ['id', 'name', 'type'],
           filter: {},
         })
         .then((res) => {

--- a/admin/src/components/TechnicalConstructionDialog.vue
+++ b/admin/src/components/TechnicalConstructionDialog.vue
@@ -188,7 +188,7 @@ watch(
       bmService
         .find({
           $limit: 100,
-          $select: ['id', 'name'],
+          $select: ['id', 'name', 'type'],
           filter: {},
         })
         .then((res) => {

--- a/backend/api/models/query.py
+++ b/backend/api/models/query.py
@@ -1,38 +1,58 @@
 from typing import List, Optional
 from sqlmodel import Field
-from api.models.domain import NaturalResource, BuildingMaterial, BuildingMaterialBase, TechnicalConstruction, TechnicalConstructionBase, BuildingBase, Professional, ProfessionalBase
+from api.models.domain import NaturalResource, NaturalResourceBase, BuildingMaterial, BuildingMaterialBase, TechnicalConstruction, TechnicalConstructionBase, BuildingBase, Professional, ProfessionalBase
 from enacit4r_sql.models.query import ListResult
 
 # Natural resources
+
+
+class NaturalResourceRead(NaturalResourceBase):
+    id: Optional[int] = Field(default=None)
+    name: Optional[str] = Field(default=None)
+    type: Optional[str] = Field(default=None)
+
+
 class NaturalResourceResult(ListResult):
-    data: List[NaturalResource] = []
+    data: List[NaturalResourceRead] = []
 
 # Building materials
+
+
 class BuildingMaterialDraft(BuildingMaterialBase):
     id: Optional[int] = Field(default=None)
     natural_resource_ids: List[int] = []
 
+
 class BuildingMaterialRead(BuildingMaterialBase):
     id: Optional[int] = Field(default=None)
-    natural_resources: List[NaturalResource] = []
+    name: Optional[str] = Field(default=None)
+    type: Optional[str] = Field(default=None)
+    natural_resources: List[NaturalResource] = None
+
 
 class BuildingMaterialResult(ListResult):
     data: List[BuildingMaterialRead] = []
 
 # Technical constructions
 
+
 class TechnicalConstructionDraft(TechnicalConstructionBase):
     id: Optional[int] = Field(default=None)
     building_material_ids: List[int] = []
 
+
 class TechnicalConstructionRead(TechnicalConstructionBase):
     id: Optional[int] = Field(default=None)
-    building_materials: List[BuildingMaterial] = []
+    name: Optional[str] = Field(default=None)
+    type: Optional[str] = Field(default=None)
+    building_materials: List[BuildingMaterial] = None
+
 
 class TechnicalConstructionResult(ListResult):
     data: List[TechnicalConstructionRead] = []
 
 # Buildings
+
 
 class BuildingDraft(BuildingBase):
     id: Optional[int] = Field(default=None)
@@ -40,25 +60,35 @@ class BuildingDraft(BuildingBase):
     technical_construction_ids: List[int] = []
     professional_ids: List[int] = []
 
+
 class BuildingRead(BuildingBase):
     id: Optional[int] = Field(default=None)
-    building_materials: List[BuildingMaterial] = []
-    technical_constructions: List[TechnicalConstruction] = []
-    professionals: List[Professional] = []
+    name: Optional[str] = Field(default=None)
+    type: Optional[str] = Field(default=None)
+    building_materials: List[BuildingMaterial] = None
+    technical_constructions: List[TechnicalConstruction] = None
+    professionals: List[Professional] = None
+
 
 class BuildingResult(ListResult):
     data: List[BuildingRead] = []
 
 # professionals
+
+
 class ProfessionalDraft(ProfessionalBase):
     id: Optional[int] = Field(default=None)
     building_material_ids: List[int] = []
     technical_construction_ids: List[int] = []
 
+
 class ProfessionalRead(ProfessionalBase):
     id: Optional[int] = Field(default=None)
-    building_materials: List[BuildingMaterial] = []
-    technical_constructions: List[TechnicalConstruction] = []
+    name: Optional[str] = Field(default=None)
+    type: Optional[str] = Field(default=None)
+    building_materials: List[BuildingMaterial] = None
+    technical_constructions: List[TechnicalConstruction] = None
+
 
 class ProfessionalResult(ListResult):
     data: List[ProfessionalRead] = []

--- a/backend/api/services/buildings.py
+++ b/backend/api/services/buildings.py
@@ -20,12 +20,14 @@ class BuildingQueryBuilder(QueryBuilder):
         query = self._apply_joins(query, filter)
         return query
 
-    def build_query_with_joins(self, total_count, filter):
-        start, end, query = self.build_query(total_count)
+    def build_query_with_joins(self, total_count, filter, fields=None):
+        start, end, query = self.build_query(total_count, fields)
         query = self._apply_joins(query, filter)
-        query = query.options(selectinload(Building.building_materials),
-                              selectinload(Building.technical_constructions),
-                              selectinload(Building.professionals))
+        if fields is None or len(fields) == 0:
+            query = query.options(selectinload(Building.building_materials),
+                                  selectinload(
+                                      Building.technical_constructions),
+                                  selectinload(Building.professionals))
         return start, end, query
 
     def _apply_joins(self, query, filter):
@@ -74,7 +76,7 @@ class BuildingService:
         await self.session.commit()
         return entity
 
-    async def find(self, filter: dict, sort: list, range: list) -> BuildingResult:
+    async def find(self, filter: dict, fields: list, sort: list, range: list) -> BuildingResult:
         """Get all buildings matching filter and range"""
         builder = BuildingQueryBuilder(Building, filter, sort, range, {
                                        "$building_materials": BuildingMaterial, "$technical_constructions": TechnicalConstruction})
@@ -85,7 +87,8 @@ class BuildingService:
         total_count = total_count_query.one()
 
         # Main query
-        start, end, query = builder.build_query_with_joins(total_count, filter)
+        start, end, query = builder.build_query_with_joins(
+            total_count, filter, fields)
 
         # Execute query
         results = await self.session.exec(query)

--- a/backend/api/services/natural_resources.py
+++ b/backend/api/services/natural_resources.py
@@ -19,8 +19,8 @@ class NaturalResourceQueryBuilder(QueryBuilder):
         query = self._apply_joins(query, filter)
         return query
 
-    def build_query_with_joins(self, total_count, filter):
-        start, end, query = self.build_query(total_count)
+    def build_query_with_joins(self, total_count, filter, fields=None):
+        start, end, query = self.build_query(total_count, fields)
         query = self._apply_joins(query, filter)
         # query = query.options(selectinload(NaturalResource.building_materials))
         return start, end, query
@@ -67,7 +67,7 @@ class NaturalResourceService:
         await self.session.commit()
         return entity
 
-    async def find(self, filter: dict, sort: list, range: list) -> NaturalResourceResult:
+    async def find(self, filter: dict, fields: list, sort: list, range: list) -> NaturalResourceResult:
         """Get all buildings matching filter and range"""
         builder = NaturalResourceQueryBuilder(NaturalResource, filter, sort, range, {
                                               "$building_materials": BuildingMaterial})
@@ -78,7 +78,8 @@ class NaturalResourceService:
         total_count = total_count_query.one()
 
         # Main query
-        start, end, query = builder.build_query_with_joins(total_count, filter)
+        start, end, query = builder.build_query_with_joins(
+            total_count, filter, fields)
 
         # Execute query
         results = await self.session.exec(query)

--- a/backend/api/views/building_materials.py
+++ b/backend/api/views/building_materials.py
@@ -12,21 +12,22 @@ router = APIRouter()
 @router.get("/", response_model=BuildingMaterialResult, response_model_exclude_none=True)
 async def find(
     filter: str = Query(None),
+    select: str = Query(None),
     sort: str = Query(None),
     range: str = Query("[0,99]"),
     session: AsyncSession = Depends(get_session),
 ) -> BuildingMaterialResult:
     """Search for building materials"""
-    return await BuildingMaterialService(session).find(paramAsDict(filter), paramAsArray(sort), paramAsArray(range))
+    return await BuildingMaterialService(session).find(paramAsDict(filter), paramAsArray(select), paramAsArray(sort), paramAsArray(range))
 
 
-@router.get("/{id}", response_model=BuildingMaterial)
+@router.get("/{id}", response_model=BuildingMaterial, response_model_exclude_none=True)
 async def get(id: int, session: AsyncSession = Depends(get_session)) -> BuildingMaterial:
     """Get a building material by id"""
     return await BuildingMaterialService(session).get(id)
 
 
-@router.delete("/{id}", response_model=BuildingMaterial)
+@router.delete("/{id}", response_model=BuildingMaterial, response_model_exclude_none=True)
 async def delete(
         id: int,
         session: AsyncSession = Depends(get_session),
@@ -35,7 +36,7 @@ async def delete(
     return await BuildingMaterialService(session).delete(id)
 
 
-@router.post("/", response_model=BuildingMaterial)
+@router.post("/", response_model=BuildingMaterial, response_model_exclude_none=True)
 async def create(
     payload: BuildingMaterialDraft,
     session: AsyncSession = Depends(get_session),
@@ -45,7 +46,7 @@ async def create(
     return await BuildingMaterialService(session).create(payload, user)
 
 
-@router.put("/{id}", response_model=BuildingMaterial)
+@router.put("/{id}", response_model=BuildingMaterial, response_model_exclude_none=True)
 async def update(
     id: int, payload: BuildingMaterialDraft,
     session: AsyncSession = Depends(get_session),

--- a/backend/api/views/buildings.py
+++ b/backend/api/views/buildings.py
@@ -12,21 +12,22 @@ router = APIRouter()
 @router.get("/", response_model=BuildingResult, response_model_exclude_none=True)
 async def find(
     filter: str = Query(None),
+    select: str = Query(None),
     sort: str = Query(None),
     range: str = Query("[0,99]"),
     session: AsyncSession = Depends(get_session),
 ) -> BuildingResult:
     """Search for buildings"""
-    return await BuildingService(session).find(paramAsDict(filter), paramAsArray(sort), paramAsArray(range))
+    return await BuildingService(session).find(paramAsDict(filter), paramAsArray(select), paramAsArray(sort), paramAsArray(range))
 
 
-@router.get("/{id}", response_model=Building)
+@router.get("/{id}", response_model=Building, response_model_exclude_none=True)
 async def get(id: int, session: AsyncSession = Depends(get_session)) -> Building:
     """Get a building by id"""
     return await BuildingService(session).get(id)
 
 
-@router.delete("/{id}", response_model=Building)
+@router.delete("/{id}", response_model=Building, response_model_exclude_none=True)
 async def delete(
         id: int,
         session: AsyncSession = Depends(get_session),
@@ -35,7 +36,7 @@ async def delete(
     return await BuildingService(session).delete(id)
 
 
-@router.post("/", response_model=Building)
+@router.post("/", response_model=Building, response_model_exclude_none=True)
 async def create(
     payload: BuildingDraft,
     session: AsyncSession = Depends(get_session),
@@ -45,7 +46,7 @@ async def create(
     return await BuildingService(session).create(payload, user)
 
 
-@router.put("/{id}", response_model=Building)
+@router.put("/{id}", response_model=Building, response_model_exclude_none=True)
 async def update(
     id: int, payload: BuildingDraft,
     session: AsyncSession = Depends(get_session),

--- a/backend/api/views/natural_resources.py
+++ b/backend/api/views/natural_resources.py
@@ -12,21 +12,22 @@ router = APIRouter()
 @router.get("/", response_model=NaturalResourceResult, response_model_exclude_none=True)
 async def find(
     filter: str = Query(None),
+    select: str = Query(None),
     sort: str = Query(None),
     range: str = Query("[0,99]"),
     session: AsyncSession = Depends(get_session),
 ) -> NaturalResourceResult:
     """Search for natural resources"""
-    return await NaturalResourceService(session).find(paramAsDict(filter), paramAsArray(sort), paramAsArray(range))
+    return await NaturalResourceService(session).find(paramAsDict(filter), paramAsArray(select), paramAsArray(sort), paramAsArray(range))
 
 
-@router.get("/{id}", response_model=NaturalResource)
+@router.get("/{id}", response_model=NaturalResource, response_model_exclude_none=True)
 async def get(id: int, session: AsyncSession = Depends(get_session)) -> NaturalResource:
     """Get a natural resource by id"""
     return await NaturalResourceService(session).get(id)
 
 
-@router.delete("/{id}", response_model=NaturalResource)
+@router.delete("/{id}", response_model=NaturalResource, response_model_exclude_none=True)
 async def delete(
     id: int,
     session: AsyncSession = Depends(get_session),
@@ -36,7 +37,7 @@ async def delete(
     return await NaturalResourceService(session).delete(id)
 
 
-@router.post("/", response_model=NaturalResource)
+@router.post("/", response_model=NaturalResource, response_model_exclude_none=True)
 async def create(
     natural_resource: NaturalResource,
     session: AsyncSession = Depends(get_session),
@@ -46,7 +47,7 @@ async def create(
     return await NaturalResourceService(session).create(natural_resource, user)
 
 
-@router.put("/{id}", response_model=NaturalResource)
+@router.put("/{id}", response_model=NaturalResource, response_model_exclude_none=True)
 async def update(
     id: int,
     natural_resource: NaturalResource,

--- a/backend/api/views/professionals.py
+++ b/backend/api/views/professionals.py
@@ -12,21 +12,22 @@ router = APIRouter()
 @router.get("/", response_model=ProfessionalResult, response_model_exclude_none=True)
 async def find(
     filter: str = Query(None),
+    select: str = Query(None),
     sort: str = Query(None),
     range: str = Query("[0,99]"),
     session: AsyncSession = Depends(get_session),
 ) -> ProfessionalResult:
     """Search for professionals"""
-    return await ProfessionalService(session).find(paramAsDict(filter), paramAsArray(sort), paramAsArray(range))
+    return await ProfessionalService(session).find(paramAsDict(filter), paramAsArray(select), paramAsArray(sort), paramAsArray(range))
 
 
-@router.get("/{id}", response_model=Professional)
+@router.get("/{id}", response_model=Professional, response_model_exclude_none=True)
 async def get(id: int, session: AsyncSession = Depends(get_session)) -> Professional:
     """Get a professional by id"""
     return await ProfessionalService(session).get(id)
 
 
-@router.delete("/{id}", response_model=Professional)
+@router.delete("/{id}", response_model=Professional, response_model_exclude_none=True)
 async def delete(
     id: int,
     session: AsyncSession = Depends(get_session),
@@ -36,7 +37,7 @@ async def delete(
     return await ProfessionalService(session).delete(id)
 
 
-@router.post("/", response_model=Professional)
+@router.post("/", response_model=Professional, response_model_exclude_none=True)
 async def create(
     payload: ProfessionalDraft,
     session: AsyncSession = Depends(get_session),
@@ -46,7 +47,7 @@ async def create(
     return await ProfessionalService(session).create(payload, user)
 
 
-@router.put("/{id}", response_model=Professional)
+@router.put("/{id}", response_model=Professional, response_model_exclude_none=True)
 async def update(
     id: int,
     payload: ProfessionalDraft,

--- a/backend/api/views/technical_constructions.py
+++ b/backend/api/views/technical_constructions.py
@@ -12,21 +12,22 @@ router = APIRouter()
 @router.get("/", response_model=TechnicalConstructionResult, response_model_exclude_none=True)
 async def find(
     filter: str = Query(None),
+    select: str = Query(None),
     sort: str = Query(None),
     range: str = Query("[0,99]"),
     session: AsyncSession = Depends(get_session),
 ) -> TechnicalConstructionResult:
     """Search for technical constructions"""
-    return await TechnicalConstructionService(session).find(paramAsDict(filter), paramAsArray(sort), paramAsArray(range))
+    return await TechnicalConstructionService(session).find(paramAsDict(filter), paramAsArray(select), paramAsArray(sort), paramAsArray(range))
 
 
-@router.get("/{id}", response_model=TechnicalConstruction)
+@router.get("/{id}", response_model=TechnicalConstruction, response_model_exclude_none=True)
 async def get(id: int, session: AsyncSession = Depends(get_session)) -> TechnicalConstruction:
     """Get a technical construction by id"""
     return await TechnicalConstructionService(session).get(id)
 
 
-@router.delete("/{id}", response_model=TechnicalConstruction)
+@router.delete("/{id}", response_model=TechnicalConstruction, response_model_exclude_none=True)
 async def delete(
     id: int,
     session: AsyncSession = Depends(get_session),
@@ -36,7 +37,7 @@ async def delete(
     return await TechnicalConstructionService(session).delete(id)
 
 
-@router.post("/", response_model=TechnicalConstruction)
+@router.post("/", response_model=TechnicalConstruction, response_model_exclude_none=True)
 async def create(
     payload: TechnicalConstructionDraft,
     session: AsyncSession = Depends(get_session),
@@ -46,7 +47,7 @@ async def create(
     return await TechnicalConstructionService(session).create(payload, user)
 
 
-@router.put("/{id}", response_model=TechnicalConstruction)
+@router.put("/{id}", response_model=TechnicalConstruction, response_model_exclude_none=True)
 async def update(
     id: int,
     payload: TechnicalConstructionDraft,

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -707,7 +707,7 @@ resolved_reference = "6b63e0bd48a47d936578e009065eb1703be5a471"
 
 [[package]]
 name = "enacit4r-sql"
-version = "0.2.0"
+version = "0.3.0"
 description = "Python SQL utils for EPFL ENAC IT4R developments"
 optional = false
 python-versions = "^3.10"
@@ -720,8 +720,8 @@ sqlmodel = "^0.0.22"
 [package.source]
 type = "git"
 url = "https://github.com/EPFL-ENAC/enacit4r-sql"
-reference = "0.2.0"
-resolved_reference = "8d0e1a6a4a704d45db024c9bbc80dc894a6a4e14"
+reference = "dev"
+resolved_reference = "23343eee2650466ad77b181a0be20d3dd607941f"
 
 [[package]]
 name = "exceptiongroup"
@@ -2149,4 +2149,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "e4fda158cb050b2fcd17078e5eadd3c9d40b8b9a5d4b483e238d626f99da5da0"
+content-hash = "104da1070914b15e36d393ae5ddb244f68596d7d5f5a3ae243f40d861dfa3176"

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -720,8 +720,8 @@ sqlmodel = "^0.0.22"
 [package.source]
 type = "git"
 url = "https://github.com/EPFL-ENAC/enacit4r-sql"
-reference = "dev"
-resolved_reference = "23343eee2650466ad77b181a0be20d3dd607941f"
+reference = "0.3.0"
+resolved_reference = "d71fc2c068fbd5496eb7996e5f87f2e9a4274417"
 
 [[package]]
 name = "exceptiongroup"
@@ -2149,4 +2149,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "104da1070914b15e36d393ae5ddb244f68596d7d5f5a3ae243f40d861dfa3176"
+content-hash = "5fc3b5e95072a18ca95646a25636e3f3dd203a5ae213f2b5c144ddcc23843915"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -12,7 +12,7 @@ python = "^3.10"
 fastapi = "^0.115.4"
 enacit4r-files = {git = "https://github.com/EPFL-ENAC/enacit4r-files", rev = "0.5.0"}
 enacit4r-auth = {git = "https://github.com/EPFL-ENAC/enacit4r-auth", rev = "0.2.0"}
-enacit4r-sql = {git = "https://github.com/EPFL-ENAC/enacit4r-sql", rev = "dev"}
+enacit4r-sql = {git = "https://github.com/EPFL-ENAC/enacit4r-sql", rev = "0.3.0"}
 alembic = "^1.14.0"
 asyncpg = "^0.30.0"
 psycopg2 = "^2.9.10"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -12,7 +12,7 @@ python = "^3.10"
 fastapi = "^0.115.4"
 enacit4r-files = {git = "https://github.com/EPFL-ENAC/enacit4r-files", rev = "0.5.0"}
 enacit4r-auth = {git = "https://github.com/EPFL-ENAC/enacit4r-auth", rev = "0.2.0"}
-enacit4r-sql = {git = "https://github.com/EPFL-ENAC/enacit4r-sql", rev = "0.2.0"}
+enacit4r-sql = {git = "https://github.com/EPFL-ENAC/enacit4r-sql", rev = "dev"}
 alembic = "^1.14.0"
 asyncpg = "^0.30.0"
 psycopg2 = "^2.9.10"


### PR DESCRIPTION
In the admin webapp, user can select a related entity (e.g. a technical-construction is made of building-materials). The query to populate these relation dropdowns only gets id, name, and type fields.¨

![image](https://github.com/user-attachments/assets/dc1d5e40-b2a4-4e48-873d-ece81b7d89d5)
